### PR TITLE
Make geometries available in waypoint lists

### DIFF
--- a/c2corg_common/fields_waypoint.py
+++ b/c2corg_common/fields_waypoint.py
@@ -17,6 +17,7 @@ DEFAULT_REQUIRED = [
 DEFAULT_LISTING = [
     'locales.title',
     'locales.summary',
+    'geometry.geom',
     'elevation'
 ]
 DEFAULT_ATTRIBUTES_SETTINGS = {


### PR DESCRIPTION
In order to have geometries available in the WP lists.
