### PR TITLE
Add title_prefix to DEFAULT_LISTING

### DIFF
--- a/c2corg_common/fields_route.py
+++ b/c2corg_common/fields_route.py
@@ -30,6 +30,7 @@ DEFAULT_REQUIRED = [
 ]
 DEFAULT_LISTING = [
     'locales.title',
+    'locales.title_prefix',
     'locales.summary',
     'elevation_max'
 ]


### PR DESCRIPTION
`title_prefix` is also needed when listing routes.
