### PR TITLE
Capitalize map editors

### DIFF
--- a/c2corg_common/attributes.py
+++ b/c2corg_common/attributes.py
@@ -493,9 +493,9 @@ mtb_down_ratings = [
 ]
 
 map_editors = [
-    'ign',
-    'swisstopo',
-    'escursionista'
+    'IGN',
+    'Swisstopo',
+    'Escursionista'
 ]
 
 map_scales = [


### PR DESCRIPTION
This way we don't need to make translations or other conversions when displaying the map editors names.
