### PR TITLE
Remove awesomeness + fix paragliding_ratings

### DIFF
--- a/c2corg_common/attributes.py
+++ b/c2corg_common/attributes.py
@@ -117,8 +117,7 @@ paragliding_ratings = [
     '2',
     '3',
     '4',
-    '5',
-    '6'
+    '5'
 ]
 
 children_proof_types = [
@@ -523,14 +522,6 @@ access_conditions = [
 lift_status = [
     'open',
     'closed'
-]
-
-awesomeness = [
-    '*',
-    '**',
-    '***',
-    '****',
-    '*****'
 ]
 
 condition_ratings = [

--- a/c2corg_common/fields_outing.py
+++ b/c2corg_common/fields_outing.py
@@ -28,7 +28,6 @@ DEFAULT_FIELDS = [
     'public_transport',
     'access_condition',
     'lift_status',
-    'awesomeness',
     'duration',
     'condition_rating',
     'hut_status',

--- a/c2corg_common/sortable_search_attributes.py
+++ b/c2corg_common/sortable_search_attributes.py
@@ -72,8 +72,7 @@ sortable_paragliding_ratings = {
     '2': 1,
     '3': 2,
     '4': 3,
-    '5': 4,
-    '6': 5
+    '5': 4
 }
 
 sortable_exposition_ratings = {


### PR DESCRIPTION
Outing attribute `awesomeness` is deprecated (should be removed in the UI and API as well!).
`paragliding_ratings` values are only from 1 to 5, see for instance http://www.camptocamp.org/summits/37737/fr/mont-de-grange
