### PR TITLE
Repair failing test for quality types

### DIFF
--- a/c2corg_common/attributes.py
+++ b/c2corg_common/attributes.py
@@ -598,7 +598,7 @@ quality_types = [
     'empty',
     'draft',
     'medium',
-    'fine',
+    'good',
     'excellent'
 ]
 


### PR DESCRIPTION
I had this problems and it is also failing travis now. I fixed quality type "fine" to "good", which is also visible on editing pages on demo UI.

dkocich@wrk32:~/projects/c2corg/v6_common$ make check
.build/venv/bin/flake8 c2corg_common
.build/venv/bin/nosetests
# F
## FAIL: Check that all values used in `sortable_search_attributes` have

Traceback (most recent call last):
  File "/home/dkocich/projects/c2corg/v6_common/c2corg_common/tests/test_sortable_search_attributes.py", line 22, in test_check_search_attributes
    self._check_values(sortable_attribute_key, original_attribute_key)
  File "/home/dkocich/projects/c2corg/v6_common/c2corg_common/tests/test_sortable_search_attributes.py", line 34, in _check_values
    val, original_attribute_key, sortable_attribute_key
AssertionError: fine defined on quality_types but not on sortable_quality_types

---

Ran 1 test in 0.009s

FAILED (failures=1)
Makefile:33: recipe for target 'test' failed
make: **\* [test] Error 1
