### PR TITLE
Split 'gear_and_technique' article category into 'gear' and 'technical'

### DIFF
--- a/c2corg_common/attributes.py
+++ b/c2corg_common/attributes.py
@@ -612,7 +612,8 @@ custodianship_types = [
 
 article_categories = [
     'mountain_environment',
-    'gear_and_technique',
+    'gear',
+    'technical',
     'topoguide_supplements',
     'soft_mobility',
     'expeditions',


### PR DESCRIPTION
The article categories was based on a old V5 dump.
Since 19 january 2016, the 'gear_and_technique' category has been splitted into 'gear' and 'technical'.
This pull request update the category list.
As the string change, it implies some changes on translation.

See also the pull request for the migration : https://github.com/c2corg/v6_api/pull/522