### PR TITLE
Make main_waypoint_id when listing routes

### DIFF
--- a/c2corg_common/fields_route.py
+++ b/c2corg_common/fields_route.py
@@ -39,6 +39,7 @@ DEFAULT_LISTING = [
     'height_diff_difficulties',
     'activities',
     'quality',
+    'main_waypoint_id',
     'orientations'
 ]
 DEFAULT_ATTRIBUTES_SETTINGS = {


### PR DESCRIPTION
Related to https://github.com/c2corg/v6_api/issues/465

Having the ``main_waypoint_id`` in the lists of routes, especially in the list of routes associated to a given waypoint, would be useful to figure out if this waypoint is the main waypoint of some of the associated routes, thus preventing it from being removed.